### PR TITLE
유저별 버튼 띄우기 / 페이지 이동 비동기처리

### DIFF
--- a/src/components/together/TogetherDelButton.js
+++ b/src/components/together/TogetherDelButton.js
@@ -14,8 +14,8 @@ export default function TogetherDelButton() {
 
     return (
         <>
-            <DeleteButton id="delBtn" onClick={() => {
-                TogetherDeleteButton();
+            <DeleteButton id="delBtn" onClick={async () => {
+                await TogetherDeleteButton();
                 navigate(`/together/${accountname}`);
             }}>삭제</DeleteButton>
         </>

--- a/src/pages/together/Together.jsx
+++ b/src/pages/together/Together.jsx
@@ -5,6 +5,7 @@ import Common from '../../components/main/Common';
 import TogetherList from '../../components/together/TogetherList';
 import WriteButton from '../../components/writebutton/WriteButton';
 import { useParams } from 'react-router';
+import EmptyPost from '../../components/post/EmptyPost';
 
 
 export default function Together() {
@@ -24,15 +25,19 @@ export default function Together() {
 
     const page = (
         <>
-            <TogetherSection>
-                <TogetherWrap>
-                    {!togetherList ? [] : togetherList.map((item) => (
-                        <TogetherList key={item.id} {...item}></TogetherList>
-                    ))}
-                </TogetherWrap>
-                <MoreButton onClick={() => setPages((pagse) => pages + 5)}>더보기</MoreButton>
-                <WriteButton url={`/together/upload`} />
-            </TogetherSection>
+            {togetherList.length ? (
+                <TogetherSection>
+                    <TogetherWrap>
+                        {!togetherList ? [] : togetherList.map((item) => (
+                            <TogetherList key={item.id} {...item}></TogetherList>
+                        ))}
+                    </TogetherWrap>
+                    <MoreButton onClick={() => setPages((pagse) => pages + 5)}>더보기</MoreButton>
+                    <WriteButton url={`/together/upload`} />
+                </TogetherSection>
+            ) : (
+                <EmptyPost url={'../together/upload'} />
+            )}
         </>
     )
     return (

--- a/src/pages/together/Together.jsx
+++ b/src/pages/together/Together.jsx
@@ -6,10 +6,12 @@ import TogetherList from '../../components/together/TogetherList';
 import WriteButton from '../../components/writebutton/WriteButton';
 import { useParams } from 'react-router';
 import EmptyPost from '../../components/post/EmptyPost';
+import { useSelector } from 'react-redux';
 
 
 export default function Together() {
     const accountname = useParams().id;
+    const myInfo = useSelector((state) => { return state.user.myInfo.accountname });
     const [pages, setPages] = useState(10);
     const [togetherList, setTogetherList] = useState([]);
 
@@ -23,6 +25,7 @@ export default function Together() {
         axiosTogetherList();
     }, [pages]);
 
+
     const page = (
         <>
             {togetherList.length ? (
@@ -33,7 +36,7 @@ export default function Together() {
                         ))}
                     </TogetherWrap>
                     <MoreButton onClick={() => setPages((pagse) => pages + 5)}>더보기</MoreButton>
-                    <WriteButton url={`/together/upload`} />
+                    {accountname === myInfo && <WriteButton url={`/together/upload`} />}
                 </TogetherSection>
             ) : (
                 <EmptyPost url={'../together/upload'} />

--- a/src/pages/together/Together.jsx
+++ b/src/pages/together/Together.jsx
@@ -35,7 +35,7 @@ export default function Together() {
                             <TogetherList key={item.id} {...item}></TogetherList>
                         ))}
                     </TogetherWrap>
-                    <MoreButton onClick={() => setPages((pagse) => pages + 5)}>더보기</MoreButton>
+                    <MoreButton onClick={() => setPages((pages) => pages + 5)}>더보기</MoreButton>
                     {accountname === myInfo && <WriteButton url={`/together/upload`} />}
                 </TogetherSection>
             ) : (

--- a/src/pages/together/TogetherDetail.jsx
+++ b/src/pages/together/TogetherDetail.jsx
@@ -11,6 +11,8 @@ import { handleErrorImg } from '../../lib/utils/validation/image/validationConte
 
 export default function TogetherDetail() {
     const a = useSelector((state) => { return state.together.req });
+    const myAccountname = useSelector((state) => { return state.user.myInfo.accountname });
+    const [userAccountname, setUserAccountname] = useState();
     const dispatch = useDispatch();
 
     const [togetherDetail, setTogetherDetail] = useState('');
@@ -19,12 +21,11 @@ export default function TogetherDetail() {
 
     const togetherDetails = async () => {
         const res = await api.get(`/product/detail/${idd}`);
-
         const detailData = res.data?.product;
         setTogetherDetail(detailData);
-        console.log(togetherDetail);
         const { itemImage, itemName, link, price } = detailData;
         dispatch(inputTogether({ itemImage, itemName, link, price }));
+        setUserAccountname(res.data?.product?.author?.accountname);
     }
 
     useEffect(() => {
@@ -44,8 +45,10 @@ export default function TogetherDetail() {
                     <GroupDetailInfo>{togetherDetail?.link}</GroupDetailInfo>
                 </GroupWrapper>
                 <GroupBtnWrap>
-                    <TogetherEditButton />
-                    <TogetherDelButton />
+                    {myAccountname === userAccountname && <>
+                        <TogetherEditButton />
+                        <TogetherDelButton />
+                    </>}
                 </GroupBtnWrap>
             </Form>
         </>

--- a/src/pages/together/TogetherEdit.jsx
+++ b/src/pages/together/TogetherEdit.jsx
@@ -50,7 +50,7 @@ export default function GroupEdit() {
                 <GroupLabel htmlFor="GroupImage">
                     <GroupImage id="PreImage" src={togetherInfo.itemImage && !/\/undefined$/.test(togetherInfo.itemImage) ? togetherInfo.itemImage : togetherImg}></GroupImage>
                 </GroupLabel>
-                <RegiButton onClick={() => { togetherEdit(); navigate(-1); }}>수 정</RegiButton>
+                <RegiButton onClick={async () => { await togetherEdit(); navigate(-1); }}>수 정</RegiButton>
             </Form>
         </>
     );

--- a/src/pages/together/TogetherUpload.jsx
+++ b/src/pages/together/TogetherUpload.jsx
@@ -40,8 +40,7 @@ export default function GroupUpload() {
             const imgRes = await urlApi.post(`/image/uploadfile`, formData);
             const img = `${BASE_URL}/${imgRes.data.filename}`;
             const togetherBody = { product: { ...togetherInfo, itemImage: img } };
-            const res = await api.post(`/product`, togetherBody, { timeout: 3000 });
-            console.log(res);
+            await api.post(`/product`, togetherBody, { timeout: 3000 });
         } catch (error) {
             console.error(error);
         }
@@ -65,7 +64,7 @@ export default function GroupUpload() {
                     {/* <GroupImage id="PreImage" src={img || togetherReq.itemImage || initialImage}></GroupImage> */}
                     <GroupImage id="PreImage" src={img || initialImage}></GroupImage>
                 </GroupLabel>
-                <RegiButton onClick={() => { sendTogether(); navigate(`/together/${accoutname}`); }}>등록</RegiButton>
+                <RegiButton onClick={async () => { await sendTogether(); navigate(`/together/${accoutname}`); }}>등록</RegiButton>
             </Form>
         </>
     );


### PR DESCRIPTION
- 모임 업로드, 수정페이지, 삭제 > 페이지 이동 비동기처리
- 본인/유저 구분하여 글쓰기, 수정, 삭제 버튼 띄우기